### PR TITLE
Add Convar to Control All lib.request Timeouts

### DIFF
--- a/modules/objectplacer/client.lua
+++ b/modules/objectplacer/client.lua
@@ -1,5 +1,7 @@
 local placingObj
 
+local requestTimeouts = GetConvarInt('renewed_requesttimeouts', 10000)
+
 -- Object placer --
 local OxTxt = {
     '-- Place Object --  \n',
@@ -37,7 +39,7 @@ exports('placeObject', function(object, dist, snapGround, text, allowedMats, off
 
     local txt = text or OxTxt
 
-    lib.requestModel(obj)
+    lib.requestModel(requestTimeouts)
 
     placingObj = CreateObject(obj, 1.0, 1.0, 1.0, false, true, true)
     SetModelAsNoLongerNeeded(obj)

--- a/modules/objects/client.lua
+++ b/modules/objects/client.lua
@@ -4,6 +4,7 @@ local object_class = require 'classes.objects'
 local objects = {}
 
 local useInteract = GetConvar('renewed_useinteract', 'false') == 'true'
+local requestTimeouts = GetConvarInt('renewed_requesttimeouts', 10000)
 local playerInstance = LocalPlayer.state.instance or 0
 
 ---goes through the array and find the index and returns that with the object
@@ -61,7 +62,7 @@ end)
 ---@param self renewed_objects
 local function createObject(self)
     if playerInstance ~= self.instance then return end
-    lib.requestModel(self.model)
+    lib.requestModel(self.model, requestTimeouts)
 
     local obj = CreateObject(self.model, self.coords.x, self.coords.y, self.coords.z, false, true, true)
     SetEntityHeading(obj, self.heading)

--- a/modules/particle/client.lua
+++ b/modules/particle/client.lua
@@ -1,5 +1,7 @@
 local entityParticle = {}
 
+local requestTimeouts = GetConvarInt('renewed_requesttimeouts', 10000)
+
 AddStateBagChangeHandler('entityParticle', nil, function(bagName, _, value)
     local entity = GetEntityFromStateBagName(bagName)
 
@@ -12,7 +14,7 @@ AddStateBagChangeHandler('entityParticle', nil, function(bagName, _, value)
 
     if value and type(value) == 'table' then
         local offset, rotation = value.offset, value.rotation
-        lib.requestNamedPtfxAsset(value.dict, 1000)
+        lib.requestNamedPtfxAsset(value.dict, requestTimeouts)
 
         UseParticleFxAsset(value.dict)
 

--- a/modules/peds/client.lua
+++ b/modules/peds/client.lua
@@ -5,11 +5,12 @@ local Peds = {}
 
 local playerInstance = LocalPlayer.state.instance or 0
 local useInteract = GetConvar('renewed_useinteract', 'false') == 'true'
+local requestTimeouts = GetConvarInt('renewed_requesttimeouts', 10000)
 
 ---Spawns the ped on enter
 ---@param self renewed_peds
 local function spawnPed(self)
-    lib.requestModel(self.model, 1000)
+    lib.requestModel(self.model, requestTimeouts)
 
     local ped = CreatePed(0, self.model, self.coords.x, self.coords.y, self.coords.z, self.heading, false, true)
 
@@ -18,7 +19,7 @@ local function spawnPed(self)
     SetBlockingOfNonTemporaryEvents(ped, self.tempevents)
 
     if self.animDict and self.animName then
-        lib.requestAnimDict(self.animDict, 1000)
+        lib.requestAnimDict(self.animDict, requestTimeouts)
         TaskPlayAnim(ped, self.animDict, self.animName, 8.0, 0, -1, 1, 0, 0, 0)
         RemoveAnimDict(self.animDict)
     end


### PR DESCRIPTION
Convar added: `renewed_requesttimeouts`

Convar added to:
- Peds module
- Objects module
- Particles module
- Object placer module

Server owners experience errors due to "unreleased assets" and slow PCs from their end users. Allows them to increase or decrease all the request timeouts within the lib.