### PR TITLE
fix: pass entities to onSpawn functions / feat: add invincible boolean to objects

### DIFF
--- a/classes/objects.lua
+++ b/classes/objects.lua
@@ -43,6 +43,7 @@ function object_class:constructor(objectData)
     self.canClimb = objectData.canClimb or false
     self.colissions = objectData.colissions
     self.hasAnim = objectData.anim and objectData.animSpeed and true or false
+    self.invincible = objectData.invincible or false
 
     if self.hasAnim then
         self.anim = objectData.anim

--- a/modules/objects/client.lua
+++ b/modules/objects/client.lua
@@ -73,6 +73,7 @@ local function createObject(self)
 
     FreezeEntityPosition(obj, self.freeze)
     SetCanClimbOnEntity(obj, self.canClimb)
+    SetEntityCanBeDamaged(obj, not self.invincible)
 
     if type(self.colissions) == 'boolean' then
         SetEntityCollision(obj, self.colissions, self.colissions)

--- a/modules/objects/client.lua
+++ b/modules/objects/client.lua
@@ -101,11 +101,11 @@ local function createObject(self)
         RemoveNamedPtfxAsset(self.particle.dict)
     end
 
+    self.object = obj
+
     if self.onSpawn then
         self.onSpawn(self)
     end
-
-    self.object = obj
 end
 
 ---Deletes the spawned object if its spawned

--- a/modules/peds/client.lua
+++ b/modules/peds/client.lua
@@ -37,13 +37,13 @@ local function spawnPed(self)
         exports.interact:AddLocalEntityInteraction(self.interact)
     end
 
+    self.entity = ped
+
     if self.onSpawn then
         self.onSpawn(self)
     end
 
     SetModelAsNoLongerNeeded(self.model)
-
-    self.entity = ped
 end
 
 ---Deletes the ped on exit


### PR DESCRIPTION
This update allows changes to be applied to an entity immediately upon spawn. Previously, the entity was not yet attached to self when onSpawn was triggered, preventing modifications at that stage.

Also allows developers to use an invincible boolean on spawned objects, giving them the ability to prevent the objects from being destroyed